### PR TITLE
- Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8.13-slim as build-stage
 
-RUN apt-get update && apt-get install -y git python3-venv
+RUN apt-get update && apt-get install -y git build-essential
 
 WORKDIR /vk-to-tgm
 


### PR DESCRIPTION
- Remove redundant python3-venv package
- Add build-essential package (to eliminate stage 6 issue with cryptg not building)